### PR TITLE
Export `ascendingLanguages` && fixs some word's case

### DIFF
--- a/src/language-data.ts
+++ b/src/language-data.ts
@@ -992,6 +992,3 @@ export const languages = [
     }
   })
 ]
-
-/// An array of ascending language descriptions for known language packages.
-export const ascendingLanguages = languages.sort((a, b) => a.name.localeCompare(b.name))

--- a/src/language-data.ts
+++ b/src/language-data.ts
@@ -527,6 +527,7 @@ export const languages = [
   }),
   LanguageDescription.of({
     name: "mIRC",
+    extensions: ["mrc"],
     load() {
       return import("@codemirror/legacy-modes/mode/mirc").then(m => legacy(m.mirc))
     }
@@ -553,7 +554,7 @@ export const languages = [
     }
   }),
   LanguageDescription.of({
-    name: "mbox",
+    name: "Mbox",
     extensions: ["mbox"],
     load() {
       return import("@codemirror/legacy-modes/mode/mbox").then(m => legacy(m.mbox))
@@ -871,7 +872,7 @@ export const languages = [
     }
   }),
   LanguageDescription.of({
-    name: "troff",
+    name: "Troff",
     extensions: ["1","2","3","4","5","6","7","8","9"],
     load() {
       return import("@codemirror/legacy-modes/mode/troff").then(m => legacy(m.troff))
@@ -970,24 +971,27 @@ export const languages = [
     }
   }),
   LanguageDescription.of({
-    name: "mscgen",
+    name: "MscGen",
     extensions: ["mscgen","mscin","msc"],
     load() {
       return import("@codemirror/legacy-modes/mode/mscgen").then(m => legacy(m.mscgen))
     }
   }),
   LanguageDescription.of({
-    name: "xu",
+    name: "Xù",
     extensions: ["xu"],
     load() {
       return import("@codemirror/legacy-modes/mode/mscgen").then(m => legacy(m.xu))
     }
   }),
   LanguageDescription.of({
-    name: "msgenny",
+    name: "MsGenny",
     extensions: ["msgenny"],
     load() {
       return import("@codemirror/legacy-modes/mode/mscgen").then(m => legacy(m.msgenny))
     }
   })
 ]
+
+/// An array of ascending language descriptions for known language packages.
+export const ascendingLanguages = languages.sort((a, b) => a.name.localeCompare(b.name))


### PR DESCRIPTION
Some reference.

- add extension
  - mIRC extension (https://fileinfo.com/extension/mrc)
- change name's case
  - mbox, short for "mailbox"
  - troff, short for "typesetter roff" (https://en.wikipedia.org/wiki/Troff)
  - mscgen, xu, msgenny https://codemirror.net/mode/mscgen/index.html

Export `ascendingLanguages` for the case who wants to get all codemirror's supported languages ascendingly.
