### PR TITLE
add Gemfile and Rakefile to ruby's filenames

### DIFF
--- a/src/language-data.ts
+++ b/src/language-data.ts
@@ -699,6 +699,7 @@ export const languages = [
     name: "Ruby",
     alias: ["jruby","macruby","rake","rb","rbx"],
     extensions: ["rb"],
+		filename: /^(Gemfile|Rakefile)$/
     load() {
       return import("@codemirror/legacy-modes/mode/ruby").then(m => legacy(m.ruby))
     }


### PR DESCRIPTION
`Gemfile` and `Rakefile` are pretty unique and are written using Ruby syntax, this adds them to the `filename` regex so that they get recognized as ruby files