### PR TITLE
Add Ruby Language support for Gemfiles and Rakefiles

### DIFF
--- a/src/language-data.ts
+++ b/src/language-data.ts
@@ -699,6 +699,7 @@ export const languages = [
     name: "Ruby",
     alias: ["jruby","macruby","rake","rb","rbx"],
     extensions: ["rb"],
+    filename: /^Gemfile$/,
     load() {
       return import("@codemirror/legacy-modes/mode/ruby").then(m => legacy(m.ruby))
     }

--- a/src/language-data.ts
+++ b/src/language-data.ts
@@ -699,7 +699,7 @@ export const languages = [
     name: "Ruby",
     alias: ["jruby","macruby","rake","rb","rbx"],
     extensions: ["rb"],
-    filename: /^Gemfile$/,
+    filename: /^(Gemfile|Rakefile)$/,
     load() {
       return import("@codemirror/legacy-modes/mode/ruby").then(m => legacy(m.ruby))
     }


### PR DESCRIPTION
Gemfiles (and Rakefiles) should have Ruby syntax highlighting and language support as they are specific to and written in Ruby.