### PR TITLE
add `webpackChunkName` to dynamic import for better output file names

### DIFF
--- a/src/language-data.ts
+++ b/src/language-data.ts
@@ -5,7 +5,7 @@ function legacy(parser: StreamParser<unknown>): LanguageSupport {
 }
 
 function sql(dialectName: keyof typeof import("@codemirror/lang-sql")) {
-  return import/* webpackChunkName: "codemirror-lang-sql" */("@codemirror/lang-sql").then(m => m.sql({dialect: (m as any)[dialectName]}))
+  return import(/*webpackChunkName: "codemirror-lang-sql"*/"@codemirror/lang-sql").then(m => m.sql({dialect: (m as any)[dialectName]}))
 }
 
 /// An array of language descriptions for known language packages.
@@ -15,7 +15,7 @@ export const languages = [
     name: "C",
     extensions: ["c","h","ino"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-cpp" */("@codemirror/lang-cpp").then(m => m.cpp())
+      return import(/*webpackChunkName: "codemirror-lang-cpp"*/"@codemirror/lang-cpp").then(m => m.cpp())
     }
   }),
   LanguageDescription.of({
@@ -23,7 +23,7 @@ export const languages = [
     alias: ["cpp"],
     extensions: ["cpp","c++","cc","cxx","hpp","h++","hh","hxx"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-cpp" */("@codemirror/lang-cpp").then(m => m.cpp())
+      return import(/*webpackChunkName: "codemirror-lang-cpp"*/"@codemirror/lang-cpp").then(m => m.cpp())
     }
   }),
   LanguageDescription.of({
@@ -36,7 +36,7 @@ export const languages = [
     name: "CSS",
     extensions: ["css"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-css" */("@codemirror/lang-css").then(m => m.css())
+      return import(/*webpackChunkName: "codemirror-lang-css"*/"@codemirror/lang-css").then(m => m.css())
     }
   }),
   LanguageDescription.of({
@@ -44,14 +44,14 @@ export const languages = [
     alias: ["xhtml"],
     extensions: ["html", "htm", "handlebars", "hbs"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-html" */("@codemirror/lang-html").then(m => m.html())
+      return import(/*webpackChunkName: "codemirror-lang-html"*/"@codemirror/lang-html").then(m => m.html())
     }
   }),
   LanguageDescription.of({
     name: "Java",
     extensions: ["java"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-java" */("@codemirror/lang-java").then(m => m.java())
+      return import(/*webpackChunkName: "codemirror-lang-java"*/"@codemirror/lang-java").then(m => m.java())
     }
   }),
   LanguageDescription.of({
@@ -59,7 +59,7 @@ export const languages = [
     alias: ["ecmascript","js","node"],
     extensions: ["js", "mjs", "cjs"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-javascript" */("@codemirror/lang-javascript").then(m => m.javascript())
+      return import(/*webpackChunkName: "codemirror-lang-javascript"*/"@codemirror/lang-javascript").then(m => m.javascript())
     }
   }),
   LanguageDescription.of({
@@ -67,14 +67,14 @@ export const languages = [
     alias: ["json5"],
     extensions: ["json","map"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-json" */("@codemirror/lang-json").then(m => m.json())
+      return import(/*webpackChunkName: "codemirror-lang-json"*/"@codemirror/lang-json").then(m => m.json())
     }
   }),
   LanguageDescription.of({
     name: "JSX",
     extensions: ["jsx"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-javascript" */("@codemirror/lang-javascript").then(m => m.javascript({jsx: true}))
+      return import(/*webpackChunkName: "codemirror-lang-javascript"*/"@codemirror/lang-javascript").then(m => m.javascript({jsx: true}))
     }
   }),
   LanguageDescription.of({
@@ -85,7 +85,7 @@ export const languages = [
     name: "Markdown",
     extensions: ["md", "markdown", "mkd"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-markdown" */("@codemirror/lang-markdown").then(m => m.markdown())
+      return import(/*webpackChunkName: "codemirror-lang-markdown"*/"@codemirror/lang-markdown").then(m => m.markdown())
     }
   }),
   LanguageDescription.of({
@@ -100,7 +100,7 @@ export const languages = [
     name: "PHP",
     extensions: ["php", "php3", "php4", "php5", "php7", "phtml"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-php" */("@codemirror/lang-php").then(m => m.php())
+      return import(/*webpackChunkName: "codemirror-lang-php"*/"@codemirror/lang-php").then(m => m.php())
     }
   }),
   LanguageDescription.of({
@@ -117,14 +117,14 @@ export const languages = [
     extensions: ["BUILD","bzl","py","pyw"],
     filename: /^(BUCK|BUILD)$/,
     load() {
-      return import/* webpackChunkName: "codemirror-lang-python" */("@codemirror/lang-python").then(m => m.python())
+      return import(/*webpackChunkName: "codemirror-lang-python"*/"@codemirror/lang-python").then(m => m.python())
     }
   }),
   LanguageDescription.of({
     name: "Rust",
     extensions: ["rs"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-rust" */("@codemirror/lang-rust").then(m => m.rust())
+      return import(/*webpackChunkName: "codemirror-lang-rust"*/"@codemirror/lang-rust").then(m => m.rust())
     }
   }),
   LanguageDescription.of({
@@ -140,7 +140,7 @@ export const languages = [
     name: "TSX",
     extensions: ["tsx"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-javascript" */("@codemirror/lang-javascript").then(m => m.javascript({jsx: true, typescript: true}))
+      return import(/*webpackChunkName: "codemirror-lang-javascript"*/"@codemirror/lang-javascript").then(m => m.javascript({jsx: true, typescript: true}))
     }
   }),
   LanguageDescription.of({
@@ -148,14 +148,14 @@ export const languages = [
     alias: ["ts"],
     extensions: ["ts"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-javascript" */("@codemirror/lang-javascript").then(m => m.javascript({typescript: true}))
+      return import(/*webpackChunkName: "codemirror-lang-javascript"*/"@codemirror/lang-javascript").then(m => m.javascript({typescript: true}))
     }
   }),
   LanguageDescription.of({
     name: "WebAssembly",
     extensions: ["wat","wast"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-wast" */("@codemirror/lang-wast").then(m => m.wast())
+      return import(/*webpackChunkName: "codemirror-lang-wast"*/"@codemirror/lang-wast").then(m => m.wast())
     }
   }),
   LanguageDescription.of({
@@ -163,7 +163,7 @@ export const languages = [
     alias: ["rss","wsdl","xsd"],
     extensions: ["xml","xsl","xsd","svg"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-xml" */("@codemirror/lang-xml").then(m => m.xml())
+      return import(/*webpackChunkName: "codemirror-lang-xml"*/"@codemirror/lang-xml").then(m => m.xml())
     }
   }),
 
@@ -173,7 +173,7 @@ export const languages = [
     name: "APL",
     extensions: ["dyalog","apl"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-apl" */("@codemirror/legacy-modes/mode/apl").then(m => legacy(m.apl))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-apl"*/"@codemirror/legacy-modes/mode/apl").then(m => legacy(m.apl))
     }
   }),
   LanguageDescription.of({
@@ -181,35 +181,35 @@ export const languages = [
     alias: ["asciiarmor"],
     extensions: ["asc","pgp","sig"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-asciiarmor" */("@codemirror/legacy-modes/mode/asciiarmor").then(m => legacy(m.asciiArmor))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-asciiarmor"*/"@codemirror/legacy-modes/mode/asciiarmor").then(m => legacy(m.asciiArmor))
     }
   }),
   LanguageDescription.of({
     name: "ASN.1",
     extensions: ["asn","asn1"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-asn1" */("@codemirror/legacy-modes/mode/asn1").then(m => legacy(m.asn1({})))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-asn1"*/"@codemirror/legacy-modes/mode/asn1").then(m => legacy(m.asn1({})))
     }
   }),
   LanguageDescription.of({
     name: "Asterisk",
     filename: /^extensions\.conf$/i,
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-asterisk" */("@codemirror/legacy-modes/mode/asterisk").then(m => legacy(m.asterisk))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-asterisk"*/"@codemirror/legacy-modes/mode/asterisk").then(m => legacy(m.asterisk))
     }
   }),
   LanguageDescription.of({
     name: "Brainfuck",
     extensions: ["b","bf"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-brainfuck" */("@codemirror/legacy-modes/mode/brainfuck").then(m => legacy(m.brainfuck))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-brainfuck"*/"@codemirror/legacy-modes/mode/brainfuck").then(m => legacy(m.brainfuck))
     }
   }),
   LanguageDescription.of({
     name: "Cobol",
     extensions: ["cob","cpy"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-cobol" */("@codemirror/legacy-modes/mode/cobol").then(m => legacy(m.cobol))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-cobol"*/"@codemirror/legacy-modes/mode/cobol").then(m => legacy(m.cobol))
     }
   }),
   LanguageDescription.of({
@@ -217,28 +217,28 @@ export const languages = [
     alias: ["csharp","cs"],
     extensions: ["cs"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-clike" */("@codemirror/legacy-modes/mode/clike").then(m => legacy(m.csharp))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-clike"*/"@codemirror/legacy-modes/mode/clike").then(m => legacy(m.csharp))
     }
   }),
   LanguageDescription.of({
     name: "Clojure",
     extensions: ["clj","cljc","cljx"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-clojure" */("@codemirror/legacy-modes/mode/clojure").then(m => legacy(m.clojure))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-clojure"*/"@codemirror/legacy-modes/mode/clojure").then(m => legacy(m.clojure))
     }
   }),
   LanguageDescription.of({
     name: "ClojureScript",
     extensions: ["cljs"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-clojure" */("@codemirror/legacy-modes/mode/clojure").then(m => legacy(m.clojure))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-clojure"*/"@codemirror/legacy-modes/mode/clojure").then(m => legacy(m.clojure))
     }
   }),
   LanguageDescription.of({
     name: "Closure Stylesheets (GSS)",
     extensions: ["gss"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-css" */("@codemirror/legacy-modes/mode/css").then(m => legacy(m.gss))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-css"*/"@codemirror/legacy-modes/mode/css").then(m => legacy(m.gss))
     }
   }),
   LanguageDescription.of({
@@ -246,7 +246,7 @@ export const languages = [
     extensions: ["cmake","cmake.in"],
     filename: /^CMakeLists\.txt$/,
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-cmake" */("@codemirror/legacy-modes/mode/cmake").then(m => legacy(m.cmake))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-cmake"*/"@codemirror/legacy-modes/mode/cmake").then(m => legacy(m.cmake))
     }
   }),
   LanguageDescription.of({
@@ -254,7 +254,7 @@ export const languages = [
     alias: ["coffee","coffee-script"],
     extensions: ["coffee"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-coffeescript" */("@codemirror/legacy-modes/mode/coffeescript").then(m => legacy(m.coffeeScript))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-coffeescript"*/"@codemirror/legacy-modes/mode/coffeescript").then(m => legacy(m.coffeeScript))
     }
   }),
   LanguageDescription.of({
@@ -262,144 +262,144 @@ export const languages = [
     alias: ["lisp"],
     extensions: ["cl","lisp","el"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-commonlisp" */("@codemirror/legacy-modes/mode/commonlisp").then(m => legacy(m.commonLisp))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-commonlisp"*/"@codemirror/legacy-modes/mode/commonlisp").then(m => legacy(m.commonLisp))
     }
   }),
   LanguageDescription.of({
     name: "Cypher",
     extensions: ["cyp","cypher"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-cypher" */("@codemirror/legacy-modes/mode/cypher").then(m => legacy(m.cypher))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-cypher"*/"@codemirror/legacy-modes/mode/cypher").then(m => legacy(m.cypher))
     }
   }),
   LanguageDescription.of({
     name: "Cython",
     extensions: ["pyx","pxd","pxi"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-python" */("@codemirror/legacy-modes/mode/python").then(m => legacy(m.cython))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-python"*/"@codemirror/legacy-modes/mode/python").then(m => legacy(m.cython))
     }
   }),
   LanguageDescription.of({
     name: "Crystal",
     extensions: ["cr"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-crystal" */("@codemirror/legacy-modes/mode/crystal").then(m => legacy(m.crystal))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-crystal"*/"@codemirror/legacy-modes/mode/crystal").then(m => legacy(m.crystal))
     }
   }),
   LanguageDescription.of({
     name: "D",
     extensions: ["d"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-d" */("@codemirror/legacy-modes/mode/d").then(m => legacy(m.d))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-d"*/"@codemirror/legacy-modes/mode/d").then(m => legacy(m.d))
     }
   }),
   LanguageDescription.of({
     name: "Dart",
     extensions: ["dart"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-clike" */("@codemirror/legacy-modes/mode/clike").then(m => legacy(m.dart))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-clike"*/"@codemirror/legacy-modes/mode/clike").then(m => legacy(m.dart))
     }
   }),
   LanguageDescription.of({
     name: "diff",
     extensions: ["diff","patch"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-diff" */("@codemirror/legacy-modes/mode/diff").then(m => legacy(m.diff))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-diff"*/"@codemirror/legacy-modes/mode/diff").then(m => legacy(m.diff))
     }
   }),
   LanguageDescription.of({
     name: "Dockerfile",
     filename: /^Dockerfile$/,
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-dockerfile" */("@codemirror/legacy-modes/mode/dockerfile").then(m => legacy(m.dockerFile))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-dockerfile"*/"@codemirror/legacy-modes/mode/dockerfile").then(m => legacy(m.dockerFile))
     }
   }),
   LanguageDescription.of({
     name: "DTD",
     extensions: ["dtd"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-dtd" */("@codemirror/legacy-modes/mode/dtd").then(m => legacy(m.dtd))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-dtd"*/"@codemirror/legacy-modes/mode/dtd").then(m => legacy(m.dtd))
     }
   }),
   LanguageDescription.of({
     name: "Dylan",
     extensions: ["dylan","dyl","intr"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-dylan" */("@codemirror/legacy-modes/mode/dylan").then(m => legacy(m.dylan))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-dylan"*/"@codemirror/legacy-modes/mode/dylan").then(m => legacy(m.dylan))
     }
   }),
   LanguageDescription.of({
     name: "EBNF",
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-ebnf" */("@codemirror/legacy-modes/mode/ebnf").then(m => legacy(m.ebnf))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-ebnf"*/"@codemirror/legacy-modes/mode/ebnf").then(m => legacy(m.ebnf))
     }
   }),
   LanguageDescription.of({
     name: "ECL",
     extensions: ["ecl"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-ecl" */("@codemirror/legacy-modes/mode/ecl").then(m => legacy(m.ecl))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-ecl"*/"@codemirror/legacy-modes/mode/ecl").then(m => legacy(m.ecl))
     }
   }),
   LanguageDescription.of({
     name: "edn",
     extensions: ["edn"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-clojure" */("@codemirror/legacy-modes/mode/clojure").then(m => legacy(m.clojure))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-clojure"*/"@codemirror/legacy-modes/mode/clojure").then(m => legacy(m.clojure))
     }
   }),
   LanguageDescription.of({
     name: "Eiffel",
     extensions: ["e"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-eiffel" */("@codemirror/legacy-modes/mode/eiffel").then(m => legacy(m.eiffel))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-eiffel"*/"@codemirror/legacy-modes/mode/eiffel").then(m => legacy(m.eiffel))
     }
   }),
   LanguageDescription.of({
     name: "Elm",
     extensions: ["elm"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-elm" */("@codemirror/legacy-modes/mode/elm").then(m => legacy(m.elm))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-elm"*/"@codemirror/legacy-modes/mode/elm").then(m => legacy(m.elm))
     }
   }),
   LanguageDescription.of({
     name: "Erlang",
     extensions: ["erl"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-erlang" */("@codemirror/legacy-modes/mode/erlang").then(m => legacy(m.erlang))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-erlang"*/"@codemirror/legacy-modes/mode/erlang").then(m => legacy(m.erlang))
     }
   }),
   LanguageDescription.of({
     name: "Esper",
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-sql" */("@codemirror/legacy-modes/mode/sql").then(m => legacy(m.esper))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-sql"*/"@codemirror/legacy-modes/mode/sql").then(m => legacy(m.esper))
     }
   }),
   LanguageDescription.of({
     name: "Factor",
     extensions: ["factor"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-factor" */("@codemirror/legacy-modes/mode/factor").then(m => legacy(m.factor))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-factor"*/"@codemirror/legacy-modes/mode/factor").then(m => legacy(m.factor))
     }
   }),
   LanguageDescription.of({
     name: "FCL",
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-fcl" */("@codemirror/legacy-modes/mode/fcl").then(m => legacy(m.fcl))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-fcl"*/"@codemirror/legacy-modes/mode/fcl").then(m => legacy(m.fcl))
     }
   }),
   LanguageDescription.of({
     name: "Forth",
     extensions: ["forth","fth","4th"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-forth" */("@codemirror/legacy-modes/mode/forth").then(m => legacy(m.forth))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-forth"*/"@codemirror/legacy-modes/mode/forth").then(m => legacy(m.forth))
     }
   }),
   LanguageDescription.of({
     name: "Fortran",
     extensions: ["f","for","f77","f90","f95"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-fortran" */("@codemirror/legacy-modes/mode/fortran").then(m => legacy(m.fortran))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-fortran"*/"@codemirror/legacy-modes/mode/fortran").then(m => legacy(m.fortran))
     }
   }),
   LanguageDescription.of({
@@ -407,28 +407,28 @@ export const languages = [
     alias: ["fsharp"],
     extensions: ["fs"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-mllike" */("@codemirror/legacy-modes/mode/mllike").then(m => legacy(m.fSharp))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-mllike"*/"@codemirror/legacy-modes/mode/mllike").then(m => legacy(m.fSharp))
     }
   }),
   LanguageDescription.of({
     name: "Gas",
     extensions: ["s"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-gas" */("@codemirror/legacy-modes/mode/gas").then(m => legacy(m.gas))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-gas"*/"@codemirror/legacy-modes/mode/gas").then(m => legacy(m.gas))
     }
   }),
   LanguageDescription.of({
     name: "Gherkin",
     extensions: ["feature"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-gherkin" */("@codemirror/legacy-modes/mode/gherkin").then(m => legacy(m.gherkin))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-gherkin"*/"@codemirror/legacy-modes/mode/gherkin").then(m => legacy(m.gherkin))
     }
   }),
   LanguageDescription.of({
     name: "Go",
     extensions: ["go"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-go" */("@codemirror/legacy-modes/mode/go").then(m => legacy(m.go))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-go"*/"@codemirror/legacy-modes/mode/go").then(m => legacy(m.go))
     }
   }),
   LanguageDescription.of({
@@ -436,41 +436,41 @@ export const languages = [
     extensions: ["groovy","gradle"],
     filename: /^Jenkinsfile$/,
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-groovy" */("@codemirror/legacy-modes/mode/groovy").then(m => legacy(m.groovy))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-groovy"*/"@codemirror/legacy-modes/mode/groovy").then(m => legacy(m.groovy))
     }
   }),
   LanguageDescription.of({
     name: "Haskell",
     extensions: ["hs"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-haskell" */("@codemirror/legacy-modes/mode/haskell").then(m => legacy(m.haskell))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-haskell"*/"@codemirror/legacy-modes/mode/haskell").then(m => legacy(m.haskell))
     }
   }),
   LanguageDescription.of({
     name: "Haxe",
     extensions: ["hx"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-haxe" */("@codemirror/legacy-modes/mode/haxe").then(m => legacy(m.haxe))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-haxe"*/"@codemirror/legacy-modes/mode/haxe").then(m => legacy(m.haxe))
     }
   }),
   LanguageDescription.of({
     name: "HXML",
     extensions: ["hxml"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-haxe" */("@codemirror/legacy-modes/mode/haxe").then(m => legacy(m.hxml))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-haxe"*/"@codemirror/legacy-modes/mode/haxe").then(m => legacy(m.hxml))
     }
   }),
   LanguageDescription.of({
     name: "HTTP",
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-http" */("@codemirror/legacy-modes/mode/http").then(m => legacy(m.http))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-http"*/"@codemirror/legacy-modes/mode/http").then(m => legacy(m.http))
     }
   }),
   LanguageDescription.of({
     name: "IDL",
     extensions: ["pro"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-idl" */("@codemirror/legacy-modes/mode/idl").then(m => legacy(m.idl))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-idl"*/"@codemirror/legacy-modes/mode/idl").then(m => legacy(m.idl))
     }
   }),
   LanguageDescription.of({
@@ -478,35 +478,35 @@ export const languages = [
     alias: ["jsonld"],
     extensions: ["jsonld"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-javascript" */("@codemirror/legacy-modes/mode/javascript").then(m => legacy(m.jsonld))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-javascript"*/"@codemirror/legacy-modes/mode/javascript").then(m => legacy(m.jsonld))
     }
   }),
   LanguageDescription.of({
     name: "Jinja2",
     extensions: ["j2","jinja","jinja2"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-jinja2" */("@codemirror/legacy-modes/mode/jinja2").then(m => legacy(m.jinja2))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-jinja2"*/"@codemirror/legacy-modes/mode/jinja2").then(m => legacy(m.jinja2))
     }
   }),
   LanguageDescription.of({
     name: "Julia",
     extensions: ["jl"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-julia" */("@codemirror/legacy-modes/mode/julia").then(m => legacy(m.julia))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-julia"*/"@codemirror/legacy-modes/mode/julia").then(m => legacy(m.julia))
     }
   }),
   LanguageDescription.of({
     name: "Kotlin",
     extensions: ["kt"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-clike" */("@codemirror/legacy-modes/mode/clike").then(m => legacy(m.kotlin))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-clike"*/"@codemirror/legacy-modes/mode/clike").then(m => legacy(m.kotlin))
     }
   }),
   LanguageDescription.of({
     name: "LESS",
     extensions: ["less"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-css" */("@codemirror/legacy-modes/mode/css").then(m => legacy(m.less))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-css"*/"@codemirror/legacy-modes/mode/css").then(m => legacy(m.less))
     }
   }),
   LanguageDescription.of({
@@ -514,70 +514,70 @@ export const languages = [
     alias: ["ls"],
     extensions: ["ls"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-livescript" */("@codemirror/legacy-modes/mode/livescript").then(m => legacy(m.liveScript))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-livescript"*/"@codemirror/legacy-modes/mode/livescript").then(m => legacy(m.liveScript))
     }
   }),
   LanguageDescription.of({
     name: "Lua",
     extensions: ["lua"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-lua" */("@codemirror/legacy-modes/mode/lua").then(m => legacy(m.lua))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-lua"*/"@codemirror/legacy-modes/mode/lua").then(m => legacy(m.lua))
     }
   }),
   LanguageDescription.of({
     name: "mIRC",
     extensions: ["mrc"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-mirc" */("@codemirror/legacy-modes/mode/mirc").then(m => legacy(m.mirc))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-mirc"*/"@codemirror/legacy-modes/mode/mirc").then(m => legacy(m.mirc))
     }
   }),
   LanguageDescription.of({
     name: "Mathematica",
     extensions: ["m","nb","wl","wls"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-mathematica" */("@codemirror/legacy-modes/mode/mathematica").then(m => legacy(m.mathematica))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-mathematica"*/"@codemirror/legacy-modes/mode/mathematica").then(m => legacy(m.mathematica))
     }
   }),
   LanguageDescription.of({
     name: "Modelica",
     extensions: ["mo"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-modelica" */("@codemirror/legacy-modes/mode/modelica").then(m => legacy(m.modelica))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-modelica"*/"@codemirror/legacy-modes/mode/modelica").then(m => legacy(m.modelica))
     }
   }),
   LanguageDescription.of({
     name: "MUMPS",
     extensions: ["mps"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-mumps" */("@codemirror/legacy-modes/mode/mumps").then(m => legacy(m.mumps))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-mumps"*/"@codemirror/legacy-modes/mode/mumps").then(m => legacy(m.mumps))
     }
   }),
   LanguageDescription.of({
     name: "Mbox",
     extensions: ["mbox"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-mbox" */("@codemirror/legacy-modes/mode/mbox").then(m => legacy(m.mbox))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-mbox"*/"@codemirror/legacy-modes/mode/mbox").then(m => legacy(m.mbox))
     }
   }),
   LanguageDescription.of({
     name: "Nginx",
     filename: /nginx.*\.conf$/i,
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-nginx" */("@codemirror/legacy-modes/mode/nginx").then(m => legacy(m.nginx))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-nginx"*/"@codemirror/legacy-modes/mode/nginx").then(m => legacy(m.nginx))
     }
   }),
   LanguageDescription.of({
     name: "NSIS",
     extensions: ["nsh","nsi"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-nsis" */("@codemirror/legacy-modes/mode/nsis").then(m => legacy(m.nsis))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-nsis"*/"@codemirror/legacy-modes/mode/nsis").then(m => legacy(m.nsis))
     }
   }),
   LanguageDescription.of({
     name: "NTriples",
     extensions: ["nt","nq"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-ntriples" */("@codemirror/legacy-modes/mode/ntriples").then(m => legacy(m.ntriples))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-ntriples"*/"@codemirror/legacy-modes/mode/ntriples").then(m => legacy(m.ntriples))
     }
   }),
   LanguageDescription.of({
@@ -585,7 +585,7 @@ export const languages = [
     alias: ["objective-c","objc"],
     extensions: ["m"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-clike" */("@codemirror/legacy-modes/mode/clike").then(m => legacy(m.objectiveC))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-clike"*/"@codemirror/legacy-modes/mode/clike").then(m => legacy(m.objectiveC))
     }
   }),
   LanguageDescription.of({
@@ -593,56 +593,56 @@ export const languages = [
     alias: ["objective-c++","objc++"],
     extensions: ["mm"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-clike" */("@codemirror/legacy-modes/mode/clike").then(m => legacy(m.objectiveCpp))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-clike"*/"@codemirror/legacy-modes/mode/clike").then(m => legacy(m.objectiveCpp))
     }
   }),
   LanguageDescription.of({
     name: "OCaml",
     extensions: ["ml","mli","mll","mly"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-mllike" */("@codemirror/legacy-modes/mode/mllike").then(m => legacy(m.oCaml))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-mllike"*/"@codemirror/legacy-modes/mode/mllike").then(m => legacy(m.oCaml))
     }
   }),
   LanguageDescription.of({
     name: "Octave",
     extensions: ["m"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-octave" */("@codemirror/legacy-modes/mode/octave").then(m => legacy(m.octave))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-octave"*/"@codemirror/legacy-modes/mode/octave").then(m => legacy(m.octave))
     }
   }),
   LanguageDescription.of({
     name: "Oz",
     extensions: ["oz"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-oz" */("@codemirror/legacy-modes/mode/oz").then(m => legacy(m.oz))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-oz"*/"@codemirror/legacy-modes/mode/oz").then(m => legacy(m.oz))
     }
   }),
   LanguageDescription.of({
     name: "Pascal",
     extensions: ["p","pas"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-pascal" */("@codemirror/legacy-modes/mode/pascal").then(m => legacy(m.pascal))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-pascal"*/"@codemirror/legacy-modes/mode/pascal").then(m => legacy(m.pascal))
     }
   }),
   LanguageDescription.of({
     name: "Perl",
     extensions: ["pl","pm"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-perl" */("@codemirror/legacy-modes/mode/perl").then(m => legacy(m.perl))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-perl"*/"@codemirror/legacy-modes/mode/perl").then(m => legacy(m.perl))
     }
   }),
   LanguageDescription.of({
     name: "Pig",
     extensions: ["pig"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-pig" */("@codemirror/legacy-modes/mode/pig").then(m => legacy(m.pig))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-pig"*/"@codemirror/legacy-modes/mode/pig").then(m => legacy(m.pig))
     }
   }),
   LanguageDescription.of({
     name: "PowerShell",
     extensions: ["ps1","psd1","psm1"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-powershell" */("@codemirror/legacy-modes/mode/powershell").then(m => legacy(m.powerShell))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-powershell"*/"@codemirror/legacy-modes/mode/powershell").then(m => legacy(m.powerShell))
     }
   }),
   LanguageDescription.of({
@@ -650,28 +650,28 @@ export const languages = [
     alias: ["ini","properties"],
     extensions: ["properties","ini","in"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-properties" */("@codemirror/legacy-modes/mode/properties").then(m => legacy(m.properties))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-properties"*/"@codemirror/legacy-modes/mode/properties").then(m => legacy(m.properties))
     }
   }),
   LanguageDescription.of({
     name: "ProtoBuf",
     extensions: ["proto"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-protobuf" */("@codemirror/legacy-modes/mode/protobuf").then(m => legacy(m.protobuf))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-protobuf"*/"@codemirror/legacy-modes/mode/protobuf").then(m => legacy(m.protobuf))
     }
   }),
   LanguageDescription.of({
     name: "Puppet",
     extensions: ["pp"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-puppet" */("@codemirror/legacy-modes/mode/puppet").then(m => legacy(m.puppet))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-puppet"*/"@codemirror/legacy-modes/mode/puppet").then(m => legacy(m.puppet))
     }
   }),
   LanguageDescription.of({
     name: "Q",
     extensions: ["q"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-q" */("@codemirror/legacy-modes/mode/q").then(m => legacy(m.q))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-q"*/"@codemirror/legacy-modes/mode/q").then(m => legacy(m.q))
     }
   }),
   LanguageDescription.of({
@@ -679,20 +679,20 @@ export const languages = [
     alias: ["rscript"],
     extensions: ["r","R"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-r" */("@codemirror/legacy-modes/mode/r").then(m => legacy(m.r))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-r"*/"@codemirror/legacy-modes/mode/r").then(m => legacy(m.r))
     }
   }),
   LanguageDescription.of({
     name: "RPM Changes",
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-rpm" */("@codemirror/legacy-modes/mode/rpm").then(m => legacy(m.rpmChanges))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-rpm"*/"@codemirror/legacy-modes/mode/rpm").then(m => legacy(m.rpmChanges))
     }
   }),
   LanguageDescription.of({
     name: "RPM Spec",
     extensions: ["spec"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-rpm" */("@codemirror/legacy-modes/mode/rpm").then(m => legacy(m.rpmSpec))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-rpm"*/"@codemirror/legacy-modes/mode/rpm").then(m => legacy(m.rpmSpec))
     }
   }),
   LanguageDescription.of({
@@ -701,42 +701,42 @@ export const languages = [
     extensions: ["rb"],
     filename: /^(Gemfile|Rakefile)$/,
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-ruby" */("@codemirror/legacy-modes/mode/ruby").then(m => legacy(m.ruby))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-ruby"*/"@codemirror/legacy-modes/mode/ruby").then(m => legacy(m.ruby))
     }
   }),
   LanguageDescription.of({
     name: "SAS",
     extensions: ["sas"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-sas" */("@codemirror/legacy-modes/mode/sas").then(m => legacy(m.sas))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-sas"*/"@codemirror/legacy-modes/mode/sas").then(m => legacy(m.sas))
     }
   }),
   LanguageDescription.of({
     name: "Sass",
     extensions: ["sass"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-sass" */("@codemirror/legacy-modes/mode/sass").then(m => legacy(m.sass))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-sass"*/"@codemirror/legacy-modes/mode/sass").then(m => legacy(m.sass))
     }
   }),
   LanguageDescription.of({
     name: "Scala",
     extensions: ["scala"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-clike" */("@codemirror/legacy-modes/mode/clike").then(m => legacy(m.scala))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-clike"*/"@codemirror/legacy-modes/mode/clike").then(m => legacy(m.scala))
     }
   }),
   LanguageDescription.of({
     name: "Scheme",
     extensions: ["scm","ss"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-scheme" */("@codemirror/legacy-modes/mode/scheme").then(m => legacy(m.scheme))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-scheme"*/"@codemirror/legacy-modes/mode/scheme").then(m => legacy(m.scheme))
     }
   }),
   LanguageDescription.of({
     name: "SCSS",
     extensions: ["scss"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-css" */("@codemirror/legacy-modes/mode/css").then(m => legacy(m.sCSS))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-css"*/"@codemirror/legacy-modes/mode/css").then(m => legacy(m.sCSS))
     }
   }),
   LanguageDescription.of({
@@ -745,34 +745,34 @@ export const languages = [
     extensions: ["sh","ksh","bash"],
     filename: /^PKGBUILD$/,
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-shell" */("@codemirror/legacy-modes/mode/shell").then(m => legacy(m.shell))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-shell"*/"@codemirror/legacy-modes/mode/shell").then(m => legacy(m.shell))
     }
   }),
   LanguageDescription.of({
     name: "Sieve",
     extensions: ["siv","sieve"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-sieve" */("@codemirror/legacy-modes/mode/sieve").then(m => legacy(m.sieve))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-sieve"*/"@codemirror/legacy-modes/mode/sieve").then(m => legacy(m.sieve))
     }
   }),
   LanguageDescription.of({
     name: "Smalltalk",
     extensions: ["st"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-smalltalk" */("@codemirror/legacy-modes/mode/smalltalk").then(m => legacy(m.smalltalk))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-smalltalk"*/"@codemirror/legacy-modes/mode/smalltalk").then(m => legacy(m.smalltalk))
     }
   }),
   LanguageDescription.of({
     name: "Solr",
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-solr" */("@codemirror/legacy-modes/mode/solr").then(m => legacy(m.solr))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-solr"*/"@codemirror/legacy-modes/mode/solr").then(m => legacy(m.solr))
     }
   }),
   LanguageDescription.of({
     name: "SML",
     extensions: ["sml","sig","fun","smackspec"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-mllike" */("@codemirror/legacy-modes/mode/mllike").then(m => legacy(m.sml))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-mllike"*/"@codemirror/legacy-modes/mode/mllike").then(m => legacy(m.sml))
     }
   }),
   LanguageDescription.of({
@@ -780,41 +780,41 @@ export const languages = [
     alias: ["sparul"],
     extensions: ["rq","sparql"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-sparql" */("@codemirror/legacy-modes/mode/sparql").then(m => legacy(m.sparql))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-sparql"*/"@codemirror/legacy-modes/mode/sparql").then(m => legacy(m.sparql))
     }
   }),
   LanguageDescription.of({
     name: "Spreadsheet",
     alias: ["excel","formula"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-spreadsheet" */("@codemirror/legacy-modes/mode/spreadsheet").then(m => legacy(m.spreadsheet))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-spreadsheet"*/"@codemirror/legacy-modes/mode/spreadsheet").then(m => legacy(m.spreadsheet))
     }
   }),
   LanguageDescription.of({
     name: "Squirrel",
     extensions: ["nut"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-clike" */("@codemirror/legacy-modes/mode/clike").then(m => legacy(m.squirrel))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-clike"*/"@codemirror/legacy-modes/mode/clike").then(m => legacy(m.squirrel))
     }
   }),
   LanguageDescription.of({
     name: "Stylus",
     extensions: ["styl"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-stylus" */("@codemirror/legacy-modes/mode/stylus").then(m => legacy(m.stylus))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-stylus"*/"@codemirror/legacy-modes/mode/stylus").then(m => legacy(m.stylus))
     }
   }),
   LanguageDescription.of({
     name: "Swift",
     extensions: ["swift"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-swift" */("@codemirror/legacy-modes/mode/swift").then(m => legacy(m.swift))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-swift"*/"@codemirror/legacy-modes/mode/swift").then(m => legacy(m.swift))
     }
   }),
   LanguageDescription.of({
     name: "sTeX",
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-stex" */("@codemirror/legacy-modes/mode/stex").then(m => legacy(m.stex))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-stex"*/"@codemirror/legacy-modes/mode/stex").then(m => legacy(m.stex))
     }
   }),
   LanguageDescription.of({
@@ -822,131 +822,131 @@ export const languages = [
     alias: ["tex"],
     extensions: ["text","ltx","tex"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-stex" */("@codemirror/legacy-modes/mode/stex").then(m => legacy(m.stex))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-stex"*/"@codemirror/legacy-modes/mode/stex").then(m => legacy(m.stex))
     }
   }),
   LanguageDescription.of({
     name: "SystemVerilog",
     extensions: ["v","sv","svh"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-verilog" */("@codemirror/legacy-modes/mode/verilog").then(m => legacy(m.verilog))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-verilog"*/"@codemirror/legacy-modes/mode/verilog").then(m => legacy(m.verilog))
     }
   }),
   LanguageDescription.of({
     name: "Tcl",
     extensions: ["tcl"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-tcl" */("@codemirror/legacy-modes/mode/tcl").then(m => legacy(m.tcl))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-tcl"*/"@codemirror/legacy-modes/mode/tcl").then(m => legacy(m.tcl))
     }
   }),
   LanguageDescription.of({
     name: "Textile",
     extensions: ["textile"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-textile" */("@codemirror/legacy-modes/mode/textile").then(m => legacy(m.textile))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-textile"*/"@codemirror/legacy-modes/mode/textile").then(m => legacy(m.textile))
     }
   }),
   LanguageDescription.of({
     name: "TiddlyWiki",
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-tiddlywiki" */("@codemirror/legacy-modes/mode/tiddlywiki").then(m => legacy(m.tiddlyWiki))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-tiddlywiki"*/"@codemirror/legacy-modes/mode/tiddlywiki").then(m => legacy(m.tiddlyWiki))
     }
   }),
   LanguageDescription.of({
     name: "Tiki wiki",
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-tiki" */("@codemirror/legacy-modes/mode/tiki").then(m => legacy(m.tiki))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-tiki"*/"@codemirror/legacy-modes/mode/tiki").then(m => legacy(m.tiki))
     }
   }),
   LanguageDescription.of({
     name: "TOML",
     extensions: ["toml"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-toml" */("@codemirror/legacy-modes/mode/toml").then(m => legacy(m.toml))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-toml"*/"@codemirror/legacy-modes/mode/toml").then(m => legacy(m.toml))
     }
   }),
   LanguageDescription.of({
     name: "Troff",
     extensions: ["1","2","3","4","5","6","7","8","9"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-troff" */("@codemirror/legacy-modes/mode/troff").then(m => legacy(m.troff))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-troff"*/"@codemirror/legacy-modes/mode/troff").then(m => legacy(m.troff))
     }
   }),
   LanguageDescription.of({
     name: "TTCN",
     extensions: ["ttcn","ttcn3","ttcnpp"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-ttcn" */("@codemirror/legacy-modes/mode/ttcn").then(m => legacy(m.ttcn))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-ttcn"*/"@codemirror/legacy-modes/mode/ttcn").then(m => legacy(m.ttcn))
     }
   }),
   LanguageDescription.of({
     name: "TTCN_CFG",
     extensions: ["cfg"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-ttcn-cfg" */("@codemirror/legacy-modes/mode/ttcn-cfg").then(m => legacy(m.ttcnCfg))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-ttcn-cfg"*/"@codemirror/legacy-modes/mode/ttcn-cfg").then(m => legacy(m.ttcnCfg))
     }
   }),
   LanguageDescription.of({
     name: "Turtle",
     extensions: ["ttl"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-turtle" */("@codemirror/legacy-modes/mode/turtle").then(m => legacy(m.turtle))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-turtle"*/"@codemirror/legacy-modes/mode/turtle").then(m => legacy(m.turtle))
     }
   }),
   LanguageDescription.of({
     name: "Web IDL",
     extensions: ["webidl"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-webidl" */("@codemirror/legacy-modes/mode/webidl").then(m => legacy(m.webIDL))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-webidl"*/"@codemirror/legacy-modes/mode/webidl").then(m => legacy(m.webIDL))
     }
   }),
   LanguageDescription.of({
     name: "VB.NET",
     extensions: ["vb"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-vb" */("@codemirror/legacy-modes/mode/vb").then(m => legacy(m.vb))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-vb"*/"@codemirror/legacy-modes/mode/vb").then(m => legacy(m.vb))
     }
   }),
   LanguageDescription.of({
     name: "VBScript",
     extensions: ["vbs"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-vbscript" */("@codemirror/legacy-modes/mode/vbscript").then(m => legacy(m.vbScript))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-vbscript"*/"@codemirror/legacy-modes/mode/vbscript").then(m => legacy(m.vbScript))
     }
   }),
   LanguageDescription.of({
     name: "Velocity",
     extensions: ["vtl"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-velocity" */("@codemirror/legacy-modes/mode/velocity").then(m => legacy(m.velocity))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-velocity"*/"@codemirror/legacy-modes/mode/velocity").then(m => legacy(m.velocity))
     }
   }),
   LanguageDescription.of({
     name: "Verilog",
     extensions: ["v"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-verilog" */("@codemirror/legacy-modes/mode/verilog").then(m => legacy(m.verilog))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-verilog"*/"@codemirror/legacy-modes/mode/verilog").then(m => legacy(m.verilog))
     }
   }),
   LanguageDescription.of({
     name: "VHDL",
     extensions: ["vhd","vhdl"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-vhdl" */("@codemirror/legacy-modes/mode/vhdl").then(m => legacy(m.vhdl))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-vhdl"*/"@codemirror/legacy-modes/mode/vhdl").then(m => legacy(m.vhdl))
     }
   }),
   LanguageDescription.of({
     name: "XQuery",
     extensions: ["xy","xquery"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-xquery" */("@codemirror/legacy-modes/mode/xquery").then(m => legacy(m.xQuery))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-xquery"*/"@codemirror/legacy-modes/mode/xquery").then(m => legacy(m.xQuery))
     }
   }),
   LanguageDescription.of({
     name: "Yacas",
     extensions: ["ys"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-yacas" */("@codemirror/legacy-modes/mode/yacas").then(m => legacy(m.yacas))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-yacas"*/"@codemirror/legacy-modes/mode/yacas").then(m => legacy(m.yacas))
     }
   }),
   LanguageDescription.of({
@@ -954,48 +954,48 @@ export const languages = [
     alias: ["yml"],
     extensions: ["yaml","yml"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-yaml" */("@codemirror/legacy-modes/mode/yaml").then(m => legacy(m.yaml))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-yaml"*/"@codemirror/legacy-modes/mode/yaml").then(m => legacy(m.yaml))
     }
   }),
   LanguageDescription.of({
     name: "Z80",
     extensions: ["z80"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-z80" */("@codemirror/legacy-modes/mode/z80").then(m => legacy(m.z80))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-z80"*/"@codemirror/legacy-modes/mode/z80").then(m => legacy(m.z80))
     }
   }),
   LanguageDescription.of({
     name: "MscGen",
     extensions: ["mscgen","mscin","msc"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-mscgen" */("@codemirror/legacy-modes/mode/mscgen").then(m => legacy(m.mscgen))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-mscgen"*/"@codemirror/legacy-modes/mode/mscgen").then(m => legacy(m.mscgen))
     }
   }),
   LanguageDescription.of({
     name: "Xù",
     extensions: ["xu"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-mscgen" */("@codemirror/legacy-modes/mode/mscgen").then(m => legacy(m.xu))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-mscgen"*/"@codemirror/legacy-modes/mode/mscgen").then(m => legacy(m.xu))
     }
   }),
   LanguageDescription.of({
     name: "MsGenny",
     extensions: ["msgenny"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-legacy-mode-mscgen" */("@codemirror/legacy-modes/mode/mscgen").then(m => legacy(m.msgenny))
+      return import(/*webpackChunkName: "codemirror-lang-legacy-mode-mscgen"*/"@codemirror/legacy-modes/mode/mscgen").then(m => legacy(m.msgenny))
     }
   }),
   LanguageDescription.of({
     name: "Vue",
     extensions: ["vue"],
     load() {
-      return import/* webpackChunkName: "codemirror-lang-vue" */("@codemirror/lang-vue").then(m => m.vue())
+      return import(/*webpackChunkName: "codemirror-lang-vue"*/"@codemirror/lang-vue").then(m => m.vue())
     }
   }),
   LanguageDescription.of({
     name: "Angular Template",
     load() {
-      return import/* webpackChunkName: "codemirror-lang-angular" */("@codemirror/lang-angular").then(m => m.angular())
+      return import(/*webpackChunkName: "codemirror-lang-angular"*/"@codemirror/lang-angular").then(m => m.angular())
     }
   })
 ]

--- a/src/language-data.ts
+++ b/src/language-data.ts
@@ -5,7 +5,7 @@ function legacy(parser: StreamParser<unknown>): LanguageSupport {
 }
 
 function sql(dialectName: keyof typeof import("@codemirror/lang-sql")) {
-  return import("@codemirror/lang-sql").then(m => m.sql({dialect: (m as any)[dialectName]}))
+  return import/* webpackChunkName: "codemirror-lang-sql" */("@codemirror/lang-sql").then(m => m.sql({dialect: (m as any)[dialectName]}))
 }
 
 /// An array of language descriptions for known language packages.
@@ -15,7 +15,7 @@ export const languages = [
     name: "C",
     extensions: ["c","h","ino"],
     load() {
-      return import("@codemirror/lang-cpp").then(m => m.cpp())
+      return import/* webpackChunkName: "codemirror-lang-cpp" */("@codemirror/lang-cpp").then(m => m.cpp())
     }
   }),
   LanguageDescription.of({
@@ -23,7 +23,7 @@ export const languages = [
     alias: ["cpp"],
     extensions: ["cpp","c++","cc","cxx","hpp","h++","hh","hxx"],
     load() {
-      return import("@codemirror/lang-cpp").then(m => m.cpp())
+      return import/* webpackChunkName: "codemirror-lang-cpp" */("@codemirror/lang-cpp").then(m => m.cpp())
     }
   }),
   LanguageDescription.of({
@@ -36,7 +36,7 @@ export const languages = [
     name: "CSS",
     extensions: ["css"],
     load() {
-      return import("@codemirror/lang-css").then(m => m.css())
+      return import/* webpackChunkName: "codemirror-lang-css" */("@codemirror/lang-css").then(m => m.css())
     }
   }),
   LanguageDescription.of({
@@ -44,14 +44,14 @@ export const languages = [
     alias: ["xhtml"],
     extensions: ["html", "htm", "handlebars", "hbs"],
     load() {
-      return import("@codemirror/lang-html").then(m => m.html())
+      return import/* webpackChunkName: "codemirror-lang-html" */("@codemirror/lang-html").then(m => m.html())
     }
   }),
   LanguageDescription.of({
     name: "Java",
     extensions: ["java"],
     load() {
-      return import("@codemirror/lang-java").then(m => m.java())
+      return import/* webpackChunkName: "codemirror-lang-java" */("@codemirror/lang-java").then(m => m.java())
     }
   }),
   LanguageDescription.of({
@@ -59,7 +59,7 @@ export const languages = [
     alias: ["ecmascript","js","node"],
     extensions: ["js", "mjs", "cjs"],
     load() {
-      return import("@codemirror/lang-javascript").then(m => m.javascript())
+      return import/* webpackChunkName: "codemirror-lang-javascript" */("@codemirror/lang-javascript").then(m => m.javascript())
     }
   }),
   LanguageDescription.of({
@@ -67,14 +67,14 @@ export const languages = [
     alias: ["json5"],
     extensions: ["json","map"],
     load() {
-      return import("@codemirror/lang-json").then(m => m.json())
+      return import/* webpackChunkName: "codemirror-lang-json" */("@codemirror/lang-json").then(m => m.json())
     }
   }),
   LanguageDescription.of({
     name: "JSX",
     extensions: ["jsx"],
     load() {
-      return import("@codemirror/lang-javascript").then(m => m.javascript({jsx: true}))
+      return import/* webpackChunkName: "codemirror-lang-javascript" */("@codemirror/lang-javascript").then(m => m.javascript({jsx: true}))
     }
   }),
   LanguageDescription.of({
@@ -85,7 +85,7 @@ export const languages = [
     name: "Markdown",
     extensions: ["md", "markdown", "mkd"],
     load() {
-      return import("@codemirror/lang-markdown").then(m => m.markdown())
+      return import/* webpackChunkName: "codemirror-lang-markdown" */("@codemirror/lang-markdown").then(m => m.markdown())
     }
   }),
   LanguageDescription.of({
@@ -100,7 +100,7 @@ export const languages = [
     name: "PHP",
     extensions: ["php", "php3", "php4", "php5", "php7", "phtml"],
     load() {
-      return import("@codemirror/lang-php").then(m => m.php())
+      return import/* webpackChunkName: "codemirror-lang-php" */("@codemirror/lang-php").then(m => m.php())
     }
   }),
   LanguageDescription.of({
@@ -117,14 +117,14 @@ export const languages = [
     extensions: ["BUILD","bzl","py","pyw"],
     filename: /^(BUCK|BUILD)$/,
     load() {
-      return import("@codemirror/lang-python").then(m => m.python())
+      return import/* webpackChunkName: "codemirror-lang-python" */("@codemirror/lang-python").then(m => m.python())
     }
   }),
   LanguageDescription.of({
     name: "Rust",
     extensions: ["rs"],
     load() {
-      return import("@codemirror/lang-rust").then(m => m.rust())
+      return import/* webpackChunkName: "codemirror-lang-rust" */("@codemirror/lang-rust").then(m => m.rust())
     }
   }),
   LanguageDescription.of({
@@ -140,7 +140,7 @@ export const languages = [
     name: "TSX",
     extensions: ["tsx"],
     load() {
-      return import("@codemirror/lang-javascript").then(m => m.javascript({jsx: true, typescript: true}))
+      return import/* webpackChunkName: "codemirror-lang-javascript" */("@codemirror/lang-javascript").then(m => m.javascript({jsx: true, typescript: true}))
     }
   }),
   LanguageDescription.of({
@@ -148,14 +148,14 @@ export const languages = [
     alias: ["ts"],
     extensions: ["ts"],
     load() {
-      return import("@codemirror/lang-javascript").then(m => m.javascript({typescript: true}))
+      return import/* webpackChunkName: "codemirror-lang-javascript" */("@codemirror/lang-javascript").then(m => m.javascript({typescript: true}))
     }
   }),
   LanguageDescription.of({
     name: "WebAssembly",
     extensions: ["wat","wast"],
     load() {
-      return import("@codemirror/lang-wast").then(m => m.wast())
+      return import/* webpackChunkName: "codemirror-lang-wast" */("@codemirror/lang-wast").then(m => m.wast())
     }
   }),
   LanguageDescription.of({
@@ -163,7 +163,7 @@ export const languages = [
     alias: ["rss","wsdl","xsd"],
     extensions: ["xml","xsl","xsd","svg"],
     load() {
-      return import("@codemirror/lang-xml").then(m => m.xml())
+      return import/* webpackChunkName: "codemirror-lang-xml" */("@codemirror/lang-xml").then(m => m.xml())
     }
   }),
 
@@ -173,7 +173,7 @@ export const languages = [
     name: "APL",
     extensions: ["dyalog","apl"],
     load() {
-      return import("@codemirror/legacy-modes/mode/apl").then(m => legacy(m.apl))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-apl" */("@codemirror/legacy-modes/mode/apl").then(m => legacy(m.apl))
     }
   }),
   LanguageDescription.of({
@@ -181,35 +181,35 @@ export const languages = [
     alias: ["asciiarmor"],
     extensions: ["asc","pgp","sig"],
     load() {
-      return import("@codemirror/legacy-modes/mode/asciiarmor").then(m => legacy(m.asciiArmor))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-asciiarmor" */("@codemirror/legacy-modes/mode/asciiarmor").then(m => legacy(m.asciiArmor))
     }
   }),
   LanguageDescription.of({
     name: "ASN.1",
     extensions: ["asn","asn1"],
     load() {
-      return import("@codemirror/legacy-modes/mode/asn1").then(m => legacy(m.asn1({})))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-asn1" */("@codemirror/legacy-modes/mode/asn1").then(m => legacy(m.asn1({})))
     }
   }),
   LanguageDescription.of({
     name: "Asterisk",
     filename: /^extensions\.conf$/i,
     load() {
-      return import("@codemirror/legacy-modes/mode/asterisk").then(m => legacy(m.asterisk))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-asterisk" */("@codemirror/legacy-modes/mode/asterisk").then(m => legacy(m.asterisk))
     }
   }),
   LanguageDescription.of({
     name: "Brainfuck",
     extensions: ["b","bf"],
     load() {
-      return import("@codemirror/legacy-modes/mode/brainfuck").then(m => legacy(m.brainfuck))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-brainfuck" */("@codemirror/legacy-modes/mode/brainfuck").then(m => legacy(m.brainfuck))
     }
   }),
   LanguageDescription.of({
     name: "Cobol",
     extensions: ["cob","cpy"],
     load() {
-      return import("@codemirror/legacy-modes/mode/cobol").then(m => legacy(m.cobol))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-cobol" */("@codemirror/legacy-modes/mode/cobol").then(m => legacy(m.cobol))
     }
   }),
   LanguageDescription.of({
@@ -217,28 +217,28 @@ export const languages = [
     alias: ["csharp","cs"],
     extensions: ["cs"],
     load() {
-      return import("@codemirror/legacy-modes/mode/clike").then(m => legacy(m.csharp))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-clike" */("@codemirror/legacy-modes/mode/clike").then(m => legacy(m.csharp))
     }
   }),
   LanguageDescription.of({
     name: "Clojure",
     extensions: ["clj","cljc","cljx"],
     load() {
-      return import("@codemirror/legacy-modes/mode/clojure").then(m => legacy(m.clojure))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-clojure" */("@codemirror/legacy-modes/mode/clojure").then(m => legacy(m.clojure))
     }
   }),
   LanguageDescription.of({
     name: "ClojureScript",
     extensions: ["cljs"],
     load() {
-      return import("@codemirror/legacy-modes/mode/clojure").then(m => legacy(m.clojure))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-clojure" */("@codemirror/legacy-modes/mode/clojure").then(m => legacy(m.clojure))
     }
   }),
   LanguageDescription.of({
     name: "Closure Stylesheets (GSS)",
     extensions: ["gss"],
     load() {
-      return import("@codemirror/legacy-modes/mode/css").then(m => legacy(m.gss))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-css" */("@codemirror/legacy-modes/mode/css").then(m => legacy(m.gss))
     }
   }),
   LanguageDescription.of({
@@ -246,7 +246,7 @@ export const languages = [
     extensions: ["cmake","cmake.in"],
     filename: /^CMakeLists\.txt$/,
     load() {
-      return import("@codemirror/legacy-modes/mode/cmake").then(m => legacy(m.cmake))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-cmake" */("@codemirror/legacy-modes/mode/cmake").then(m => legacy(m.cmake))
     }
   }),
   LanguageDescription.of({
@@ -254,7 +254,7 @@ export const languages = [
     alias: ["coffee","coffee-script"],
     extensions: ["coffee"],
     load() {
-      return import("@codemirror/legacy-modes/mode/coffeescript").then(m => legacy(m.coffeeScript))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-coffeescript" */("@codemirror/legacy-modes/mode/coffeescript").then(m => legacy(m.coffeeScript))
     }
   }),
   LanguageDescription.of({
@@ -262,144 +262,144 @@ export const languages = [
     alias: ["lisp"],
     extensions: ["cl","lisp","el"],
     load() {
-      return import("@codemirror/legacy-modes/mode/commonlisp").then(m => legacy(m.commonLisp))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-commonlisp" */("@codemirror/legacy-modes/mode/commonlisp").then(m => legacy(m.commonLisp))
     }
   }),
   LanguageDescription.of({
     name: "Cypher",
     extensions: ["cyp","cypher"],
     load() {
-      return import("@codemirror/legacy-modes/mode/cypher").then(m => legacy(m.cypher))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-cypher" */("@codemirror/legacy-modes/mode/cypher").then(m => legacy(m.cypher))
     }
   }),
   LanguageDescription.of({
     name: "Cython",
     extensions: ["pyx","pxd","pxi"],
     load() {
-      return import("@codemirror/legacy-modes/mode/python").then(m => legacy(m.cython))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-python" */("@codemirror/legacy-modes/mode/python").then(m => legacy(m.cython))
     }
   }),
   LanguageDescription.of({
     name: "Crystal",
     extensions: ["cr"],
     load() {
-      return import("@codemirror/legacy-modes/mode/crystal").then(m => legacy(m.crystal))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-crystal" */("@codemirror/legacy-modes/mode/crystal").then(m => legacy(m.crystal))
     }
   }),
   LanguageDescription.of({
     name: "D",
     extensions: ["d"],
     load() {
-      return import("@codemirror/legacy-modes/mode/d").then(m => legacy(m.d))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-d" */("@codemirror/legacy-modes/mode/d").then(m => legacy(m.d))
     }
   }),
   LanguageDescription.of({
     name: "Dart",
     extensions: ["dart"],
     load() {
-      return import("@codemirror/legacy-modes/mode/clike").then(m => legacy(m.dart))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-clike" */("@codemirror/legacy-modes/mode/clike").then(m => legacy(m.dart))
     }
   }),
   LanguageDescription.of({
     name: "diff",
     extensions: ["diff","patch"],
     load() {
-      return import("@codemirror/legacy-modes/mode/diff").then(m => legacy(m.diff))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-diff" */("@codemirror/legacy-modes/mode/diff").then(m => legacy(m.diff))
     }
   }),
   LanguageDescription.of({
     name: "Dockerfile",
     filename: /^Dockerfile$/,
     load() {
-      return import("@codemirror/legacy-modes/mode/dockerfile").then(m => legacy(m.dockerFile))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-dockerfile" */("@codemirror/legacy-modes/mode/dockerfile").then(m => legacy(m.dockerFile))
     }
   }),
   LanguageDescription.of({
     name: "DTD",
     extensions: ["dtd"],
     load() {
-      return import("@codemirror/legacy-modes/mode/dtd").then(m => legacy(m.dtd))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-dtd" */("@codemirror/legacy-modes/mode/dtd").then(m => legacy(m.dtd))
     }
   }),
   LanguageDescription.of({
     name: "Dylan",
     extensions: ["dylan","dyl","intr"],
     load() {
-      return import("@codemirror/legacy-modes/mode/dylan").then(m => legacy(m.dylan))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-dylan" */("@codemirror/legacy-modes/mode/dylan").then(m => legacy(m.dylan))
     }
   }),
   LanguageDescription.of({
     name: "EBNF",
     load() {
-      return import("@codemirror/legacy-modes/mode/ebnf").then(m => legacy(m.ebnf))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-ebnf" */("@codemirror/legacy-modes/mode/ebnf").then(m => legacy(m.ebnf))
     }
   }),
   LanguageDescription.of({
     name: "ECL",
     extensions: ["ecl"],
     load() {
-      return import("@codemirror/legacy-modes/mode/ecl").then(m => legacy(m.ecl))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-ecl" */("@codemirror/legacy-modes/mode/ecl").then(m => legacy(m.ecl))
     }
   }),
   LanguageDescription.of({
     name: "edn",
     extensions: ["edn"],
     load() {
-      return import("@codemirror/legacy-modes/mode/clojure").then(m => legacy(m.clojure))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-clojure" */("@codemirror/legacy-modes/mode/clojure").then(m => legacy(m.clojure))
     }
   }),
   LanguageDescription.of({
     name: "Eiffel",
     extensions: ["e"],
     load() {
-      return import("@codemirror/legacy-modes/mode/eiffel").then(m => legacy(m.eiffel))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-eiffel" */("@codemirror/legacy-modes/mode/eiffel").then(m => legacy(m.eiffel))
     }
   }),
   LanguageDescription.of({
     name: "Elm",
     extensions: ["elm"],
     load() {
-      return import("@codemirror/legacy-modes/mode/elm").then(m => legacy(m.elm))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-elm" */("@codemirror/legacy-modes/mode/elm").then(m => legacy(m.elm))
     }
   }),
   LanguageDescription.of({
     name: "Erlang",
     extensions: ["erl"],
     load() {
-      return import("@codemirror/legacy-modes/mode/erlang").then(m => legacy(m.erlang))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-erlang" */("@codemirror/legacy-modes/mode/erlang").then(m => legacy(m.erlang))
     }
   }),
   LanguageDescription.of({
     name: "Esper",
     load() {
-      return import("@codemirror/legacy-modes/mode/sql").then(m => legacy(m.esper))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-sql" */("@codemirror/legacy-modes/mode/sql").then(m => legacy(m.esper))
     }
   }),
   LanguageDescription.of({
     name: "Factor",
     extensions: ["factor"],
     load() {
-      return import("@codemirror/legacy-modes/mode/factor").then(m => legacy(m.factor))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-factor" */("@codemirror/legacy-modes/mode/factor").then(m => legacy(m.factor))
     }
   }),
   LanguageDescription.of({
     name: "FCL",
     load() {
-      return import("@codemirror/legacy-modes/mode/fcl").then(m => legacy(m.fcl))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-fcl" */("@codemirror/legacy-modes/mode/fcl").then(m => legacy(m.fcl))
     }
   }),
   LanguageDescription.of({
     name: "Forth",
     extensions: ["forth","fth","4th"],
     load() {
-      return import("@codemirror/legacy-modes/mode/forth").then(m => legacy(m.forth))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-forth" */("@codemirror/legacy-modes/mode/forth").then(m => legacy(m.forth))
     }
   }),
   LanguageDescription.of({
     name: "Fortran",
     extensions: ["f","for","f77","f90","f95"],
     load() {
-      return import("@codemirror/legacy-modes/mode/fortran").then(m => legacy(m.fortran))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-fortran" */("@codemirror/legacy-modes/mode/fortran").then(m => legacy(m.fortran))
     }
   }),
   LanguageDescription.of({
@@ -407,28 +407,28 @@ export const languages = [
     alias: ["fsharp"],
     extensions: ["fs"],
     load() {
-      return import("@codemirror/legacy-modes/mode/mllike").then(m => legacy(m.fSharp))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-mllike" */("@codemirror/legacy-modes/mode/mllike").then(m => legacy(m.fSharp))
     }
   }),
   LanguageDescription.of({
     name: "Gas",
     extensions: ["s"],
     load() {
-      return import("@codemirror/legacy-modes/mode/gas").then(m => legacy(m.gas))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-gas" */("@codemirror/legacy-modes/mode/gas").then(m => legacy(m.gas))
     }
   }),
   LanguageDescription.of({
     name: "Gherkin",
     extensions: ["feature"],
     load() {
-      return import("@codemirror/legacy-modes/mode/gherkin").then(m => legacy(m.gherkin))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-gherkin" */("@codemirror/legacy-modes/mode/gherkin").then(m => legacy(m.gherkin))
     }
   }),
   LanguageDescription.of({
     name: "Go",
     extensions: ["go"],
     load() {
-      return import("@codemirror/legacy-modes/mode/go").then(m => legacy(m.go))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-go" */("@codemirror/legacy-modes/mode/go").then(m => legacy(m.go))
     }
   }),
   LanguageDescription.of({
@@ -436,41 +436,41 @@ export const languages = [
     extensions: ["groovy","gradle"],
     filename: /^Jenkinsfile$/,
     load() {
-      return import("@codemirror/legacy-modes/mode/groovy").then(m => legacy(m.groovy))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-groovy" */("@codemirror/legacy-modes/mode/groovy").then(m => legacy(m.groovy))
     }
   }),
   LanguageDescription.of({
     name: "Haskell",
     extensions: ["hs"],
     load() {
-      return import("@codemirror/legacy-modes/mode/haskell").then(m => legacy(m.haskell))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-haskell" */("@codemirror/legacy-modes/mode/haskell").then(m => legacy(m.haskell))
     }
   }),
   LanguageDescription.of({
     name: "Haxe",
     extensions: ["hx"],
     load() {
-      return import("@codemirror/legacy-modes/mode/haxe").then(m => legacy(m.haxe))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-haxe" */("@codemirror/legacy-modes/mode/haxe").then(m => legacy(m.haxe))
     }
   }),
   LanguageDescription.of({
     name: "HXML",
     extensions: ["hxml"],
     load() {
-      return import("@codemirror/legacy-modes/mode/haxe").then(m => legacy(m.hxml))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-haxe" */("@codemirror/legacy-modes/mode/haxe").then(m => legacy(m.hxml))
     }
   }),
   LanguageDescription.of({
     name: "HTTP",
     load() {
-      return import("@codemirror/legacy-modes/mode/http").then(m => legacy(m.http))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-http" */("@codemirror/legacy-modes/mode/http").then(m => legacy(m.http))
     }
   }),
   LanguageDescription.of({
     name: "IDL",
     extensions: ["pro"],
     load() {
-      return import("@codemirror/legacy-modes/mode/idl").then(m => legacy(m.idl))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-idl" */("@codemirror/legacy-modes/mode/idl").then(m => legacy(m.idl))
     }
   }),
   LanguageDescription.of({
@@ -478,35 +478,35 @@ export const languages = [
     alias: ["jsonld"],
     extensions: ["jsonld"],
     load() {
-      return import("@codemirror/legacy-modes/mode/javascript").then(m => legacy(m.jsonld))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-javascript" */("@codemirror/legacy-modes/mode/javascript").then(m => legacy(m.jsonld))
     }
   }),
   LanguageDescription.of({
     name: "Jinja2",
     extensions: ["j2","jinja","jinja2"],
     load() {
-      return import("@codemirror/legacy-modes/mode/jinja2").then(m => legacy(m.jinja2))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-jinja2" */("@codemirror/legacy-modes/mode/jinja2").then(m => legacy(m.jinja2))
     }
   }),
   LanguageDescription.of({
     name: "Julia",
     extensions: ["jl"],
     load() {
-      return import("@codemirror/legacy-modes/mode/julia").then(m => legacy(m.julia))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-julia" */("@codemirror/legacy-modes/mode/julia").then(m => legacy(m.julia))
     }
   }),
   LanguageDescription.of({
     name: "Kotlin",
     extensions: ["kt"],
     load() {
-      return import("@codemirror/legacy-modes/mode/clike").then(m => legacy(m.kotlin))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-clike" */("@codemirror/legacy-modes/mode/clike").then(m => legacy(m.kotlin))
     }
   }),
   LanguageDescription.of({
     name: "LESS",
     extensions: ["less"],
     load() {
-      return import("@codemirror/legacy-modes/mode/css").then(m => legacy(m.less))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-css" */("@codemirror/legacy-modes/mode/css").then(m => legacy(m.less))
     }
   }),
   LanguageDescription.of({
@@ -514,70 +514,70 @@ export const languages = [
     alias: ["ls"],
     extensions: ["ls"],
     load() {
-      return import("@codemirror/legacy-modes/mode/livescript").then(m => legacy(m.liveScript))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-livescript" */("@codemirror/legacy-modes/mode/livescript").then(m => legacy(m.liveScript))
     }
   }),
   LanguageDescription.of({
     name: "Lua",
     extensions: ["lua"],
     load() {
-      return import("@codemirror/legacy-modes/mode/lua").then(m => legacy(m.lua))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-lua" */("@codemirror/legacy-modes/mode/lua").then(m => legacy(m.lua))
     }
   }),
   LanguageDescription.of({
     name: "mIRC",
     extensions: ["mrc"],
     load() {
-      return import("@codemirror/legacy-modes/mode/mirc").then(m => legacy(m.mirc))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-mirc" */("@codemirror/legacy-modes/mode/mirc").then(m => legacy(m.mirc))
     }
   }),
   LanguageDescription.of({
     name: "Mathematica",
     extensions: ["m","nb","wl","wls"],
     load() {
-      return import("@codemirror/legacy-modes/mode/mathematica").then(m => legacy(m.mathematica))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-mathematica" */("@codemirror/legacy-modes/mode/mathematica").then(m => legacy(m.mathematica))
     }
   }),
   LanguageDescription.of({
     name: "Modelica",
     extensions: ["mo"],
     load() {
-      return import("@codemirror/legacy-modes/mode/modelica").then(m => legacy(m.modelica))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-modelica" */("@codemirror/legacy-modes/mode/modelica").then(m => legacy(m.modelica))
     }
   }),
   LanguageDescription.of({
     name: "MUMPS",
     extensions: ["mps"],
     load() {
-      return import("@codemirror/legacy-modes/mode/mumps").then(m => legacy(m.mumps))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-mumps" */("@codemirror/legacy-modes/mode/mumps").then(m => legacy(m.mumps))
     }
   }),
   LanguageDescription.of({
     name: "Mbox",
     extensions: ["mbox"],
     load() {
-      return import("@codemirror/legacy-modes/mode/mbox").then(m => legacy(m.mbox))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-mbox" */("@codemirror/legacy-modes/mode/mbox").then(m => legacy(m.mbox))
     }
   }),
   LanguageDescription.of({
     name: "Nginx",
     filename: /nginx.*\.conf$/i,
     load() {
-      return import("@codemirror/legacy-modes/mode/nginx").then(m => legacy(m.nginx))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-nginx" */("@codemirror/legacy-modes/mode/nginx").then(m => legacy(m.nginx))
     }
   }),
   LanguageDescription.of({
     name: "NSIS",
     extensions: ["nsh","nsi"],
     load() {
-      return import("@codemirror/legacy-modes/mode/nsis").then(m => legacy(m.nsis))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-nsis" */("@codemirror/legacy-modes/mode/nsis").then(m => legacy(m.nsis))
     }
   }),
   LanguageDescription.of({
     name: "NTriples",
     extensions: ["nt","nq"],
     load() {
-      return import("@codemirror/legacy-modes/mode/ntriples").then(m => legacy(m.ntriples))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-ntriples" */("@codemirror/legacy-modes/mode/ntriples").then(m => legacy(m.ntriples))
     }
   }),
   LanguageDescription.of({
@@ -585,7 +585,7 @@ export const languages = [
     alias: ["objective-c","objc"],
     extensions: ["m"],
     load() {
-      return import("@codemirror/legacy-modes/mode/clike").then(m => legacy(m.objectiveC))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-clike" */("@codemirror/legacy-modes/mode/clike").then(m => legacy(m.objectiveC))
     }
   }),
   LanguageDescription.of({
@@ -593,56 +593,56 @@ export const languages = [
     alias: ["objective-c++","objc++"],
     extensions: ["mm"],
     load() {
-      return import("@codemirror/legacy-modes/mode/clike").then(m => legacy(m.objectiveCpp))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-clike" */("@codemirror/legacy-modes/mode/clike").then(m => legacy(m.objectiveCpp))
     }
   }),
   LanguageDescription.of({
     name: "OCaml",
     extensions: ["ml","mli","mll","mly"],
     load() {
-      return import("@codemirror/legacy-modes/mode/mllike").then(m => legacy(m.oCaml))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-mllike" */("@codemirror/legacy-modes/mode/mllike").then(m => legacy(m.oCaml))
     }
   }),
   LanguageDescription.of({
     name: "Octave",
     extensions: ["m"],
     load() {
-      return import("@codemirror/legacy-modes/mode/octave").then(m => legacy(m.octave))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-octave" */("@codemirror/legacy-modes/mode/octave").then(m => legacy(m.octave))
     }
   }),
   LanguageDescription.of({
     name: "Oz",
     extensions: ["oz"],
     load() {
-      return import("@codemirror/legacy-modes/mode/oz").then(m => legacy(m.oz))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-oz" */("@codemirror/legacy-modes/mode/oz").then(m => legacy(m.oz))
     }
   }),
   LanguageDescription.of({
     name: "Pascal",
     extensions: ["p","pas"],
     load() {
-      return import("@codemirror/legacy-modes/mode/pascal").then(m => legacy(m.pascal))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-pascal" */("@codemirror/legacy-modes/mode/pascal").then(m => legacy(m.pascal))
     }
   }),
   LanguageDescription.of({
     name: "Perl",
     extensions: ["pl","pm"],
     load() {
-      return import("@codemirror/legacy-modes/mode/perl").then(m => legacy(m.perl))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-perl" */("@codemirror/legacy-modes/mode/perl").then(m => legacy(m.perl))
     }
   }),
   LanguageDescription.of({
     name: "Pig",
     extensions: ["pig"],
     load() {
-      return import("@codemirror/legacy-modes/mode/pig").then(m => legacy(m.pig))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-pig" */("@codemirror/legacy-modes/mode/pig").then(m => legacy(m.pig))
     }
   }),
   LanguageDescription.of({
     name: "PowerShell",
     extensions: ["ps1","psd1","psm1"],
     load() {
-      return import("@codemirror/legacy-modes/mode/powershell").then(m => legacy(m.powerShell))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-powershell" */("@codemirror/legacy-modes/mode/powershell").then(m => legacy(m.powerShell))
     }
   }),
   LanguageDescription.of({
@@ -650,28 +650,28 @@ export const languages = [
     alias: ["ini","properties"],
     extensions: ["properties","ini","in"],
     load() {
-      return import("@codemirror/legacy-modes/mode/properties").then(m => legacy(m.properties))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-properties" */("@codemirror/legacy-modes/mode/properties").then(m => legacy(m.properties))
     }
   }),
   LanguageDescription.of({
     name: "ProtoBuf",
     extensions: ["proto"],
     load() {
-      return import("@codemirror/legacy-modes/mode/protobuf").then(m => legacy(m.protobuf))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-protobuf" */("@codemirror/legacy-modes/mode/protobuf").then(m => legacy(m.protobuf))
     }
   }),
   LanguageDescription.of({
     name: "Puppet",
     extensions: ["pp"],
     load() {
-      return import("@codemirror/legacy-modes/mode/puppet").then(m => legacy(m.puppet))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-puppet" */("@codemirror/legacy-modes/mode/puppet").then(m => legacy(m.puppet))
     }
   }),
   LanguageDescription.of({
     name: "Q",
     extensions: ["q"],
     load() {
-      return import("@codemirror/legacy-modes/mode/q").then(m => legacy(m.q))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-q" */("@codemirror/legacy-modes/mode/q").then(m => legacy(m.q))
     }
   }),
   LanguageDescription.of({
@@ -679,20 +679,20 @@ export const languages = [
     alias: ["rscript"],
     extensions: ["r","R"],
     load() {
-      return import("@codemirror/legacy-modes/mode/r").then(m => legacy(m.r))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-r" */("@codemirror/legacy-modes/mode/r").then(m => legacy(m.r))
     }
   }),
   LanguageDescription.of({
     name: "RPM Changes",
     load() {
-      return import("@codemirror/legacy-modes/mode/rpm").then(m => legacy(m.rpmChanges))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-rpm" */("@codemirror/legacy-modes/mode/rpm").then(m => legacy(m.rpmChanges))
     }
   }),
   LanguageDescription.of({
     name: "RPM Spec",
     extensions: ["spec"],
     load() {
-      return import("@codemirror/legacy-modes/mode/rpm").then(m => legacy(m.rpmSpec))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-rpm" */("@codemirror/legacy-modes/mode/rpm").then(m => legacy(m.rpmSpec))
     }
   }),
   LanguageDescription.of({
@@ -701,42 +701,42 @@ export const languages = [
     extensions: ["rb"],
     filename: /^(Gemfile|Rakefile)$/,
     load() {
-      return import("@codemirror/legacy-modes/mode/ruby").then(m => legacy(m.ruby))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-ruby" */("@codemirror/legacy-modes/mode/ruby").then(m => legacy(m.ruby))
     }
   }),
   LanguageDescription.of({
     name: "SAS",
     extensions: ["sas"],
     load() {
-      return import("@codemirror/legacy-modes/mode/sas").then(m => legacy(m.sas))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-sas" */("@codemirror/legacy-modes/mode/sas").then(m => legacy(m.sas))
     }
   }),
   LanguageDescription.of({
     name: "Sass",
     extensions: ["sass"],
     load() {
-      return import("@codemirror/legacy-modes/mode/sass").then(m => legacy(m.sass))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-sass" */("@codemirror/legacy-modes/mode/sass").then(m => legacy(m.sass))
     }
   }),
   LanguageDescription.of({
     name: "Scala",
     extensions: ["scala"],
     load() {
-      return import("@codemirror/legacy-modes/mode/clike").then(m => legacy(m.scala))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-clike" */("@codemirror/legacy-modes/mode/clike").then(m => legacy(m.scala))
     }
   }),
   LanguageDescription.of({
     name: "Scheme",
     extensions: ["scm","ss"],
     load() {
-      return import("@codemirror/legacy-modes/mode/scheme").then(m => legacy(m.scheme))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-scheme" */("@codemirror/legacy-modes/mode/scheme").then(m => legacy(m.scheme))
     }
   }),
   LanguageDescription.of({
     name: "SCSS",
     extensions: ["scss"],
     load() {
-      return import("@codemirror/legacy-modes/mode/css").then(m => legacy(m.sCSS))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-css" */("@codemirror/legacy-modes/mode/css").then(m => legacy(m.sCSS))
     }
   }),
   LanguageDescription.of({
@@ -745,34 +745,34 @@ export const languages = [
     extensions: ["sh","ksh","bash"],
     filename: /^PKGBUILD$/,
     load() {
-      return import("@codemirror/legacy-modes/mode/shell").then(m => legacy(m.shell))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-shell" */("@codemirror/legacy-modes/mode/shell").then(m => legacy(m.shell))
     }
   }),
   LanguageDescription.of({
     name: "Sieve",
     extensions: ["siv","sieve"],
     load() {
-      return import("@codemirror/legacy-modes/mode/sieve").then(m => legacy(m.sieve))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-sieve" */("@codemirror/legacy-modes/mode/sieve").then(m => legacy(m.sieve))
     }
   }),
   LanguageDescription.of({
     name: "Smalltalk",
     extensions: ["st"],
     load() {
-      return import("@codemirror/legacy-modes/mode/smalltalk").then(m => legacy(m.smalltalk))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-smalltalk" */("@codemirror/legacy-modes/mode/smalltalk").then(m => legacy(m.smalltalk))
     }
   }),
   LanguageDescription.of({
     name: "Solr",
     load() {
-      return import("@codemirror/legacy-modes/mode/solr").then(m => legacy(m.solr))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-solr" */("@codemirror/legacy-modes/mode/solr").then(m => legacy(m.solr))
     }
   }),
   LanguageDescription.of({
     name: "SML",
     extensions: ["sml","sig","fun","smackspec"],
     load() {
-      return import("@codemirror/legacy-modes/mode/mllike").then(m => legacy(m.sml))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-mllike" */("@codemirror/legacy-modes/mode/mllike").then(m => legacy(m.sml))
     }
   }),
   LanguageDescription.of({
@@ -780,41 +780,41 @@ export const languages = [
     alias: ["sparul"],
     extensions: ["rq","sparql"],
     load() {
-      return import("@codemirror/legacy-modes/mode/sparql").then(m => legacy(m.sparql))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-sparql" */("@codemirror/legacy-modes/mode/sparql").then(m => legacy(m.sparql))
     }
   }),
   LanguageDescription.of({
     name: "Spreadsheet",
     alias: ["excel","formula"],
     load() {
-      return import("@codemirror/legacy-modes/mode/spreadsheet").then(m => legacy(m.spreadsheet))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-spreadsheet" */("@codemirror/legacy-modes/mode/spreadsheet").then(m => legacy(m.spreadsheet))
     }
   }),
   LanguageDescription.of({
     name: "Squirrel",
     extensions: ["nut"],
     load() {
-      return import("@codemirror/legacy-modes/mode/clike").then(m => legacy(m.squirrel))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-clike" */("@codemirror/legacy-modes/mode/clike").then(m => legacy(m.squirrel))
     }
   }),
   LanguageDescription.of({
     name: "Stylus",
     extensions: ["styl"],
     load() {
-      return import("@codemirror/legacy-modes/mode/stylus").then(m => legacy(m.stylus))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-stylus" */("@codemirror/legacy-modes/mode/stylus").then(m => legacy(m.stylus))
     }
   }),
   LanguageDescription.of({
     name: "Swift",
     extensions: ["swift"],
     load() {
-      return import("@codemirror/legacy-modes/mode/swift").then(m => legacy(m.swift))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-swift" */("@codemirror/legacy-modes/mode/swift").then(m => legacy(m.swift))
     }
   }),
   LanguageDescription.of({
     name: "sTeX",
     load() {
-      return import("@codemirror/legacy-modes/mode/stex").then(m => legacy(m.stex))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-stex" */("@codemirror/legacy-modes/mode/stex").then(m => legacy(m.stex))
     }
   }),
   LanguageDescription.of({
@@ -822,131 +822,131 @@ export const languages = [
     alias: ["tex"],
     extensions: ["text","ltx","tex"],
     load() {
-      return import("@codemirror/legacy-modes/mode/stex").then(m => legacy(m.stex))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-stex" */("@codemirror/legacy-modes/mode/stex").then(m => legacy(m.stex))
     }
   }),
   LanguageDescription.of({
     name: "SystemVerilog",
     extensions: ["v","sv","svh"],
     load() {
-      return import("@codemirror/legacy-modes/mode/verilog").then(m => legacy(m.verilog))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-verilog" */("@codemirror/legacy-modes/mode/verilog").then(m => legacy(m.verilog))
     }
   }),
   LanguageDescription.of({
     name: "Tcl",
     extensions: ["tcl"],
     load() {
-      return import("@codemirror/legacy-modes/mode/tcl").then(m => legacy(m.tcl))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-tcl" */("@codemirror/legacy-modes/mode/tcl").then(m => legacy(m.tcl))
     }
   }),
   LanguageDescription.of({
     name: "Textile",
     extensions: ["textile"],
     load() {
-      return import("@codemirror/legacy-modes/mode/textile").then(m => legacy(m.textile))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-textile" */("@codemirror/legacy-modes/mode/textile").then(m => legacy(m.textile))
     }
   }),
   LanguageDescription.of({
     name: "TiddlyWiki",
     load() {
-      return import("@codemirror/legacy-modes/mode/tiddlywiki").then(m => legacy(m.tiddlyWiki))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-tiddlywiki" */("@codemirror/legacy-modes/mode/tiddlywiki").then(m => legacy(m.tiddlyWiki))
     }
   }),
   LanguageDescription.of({
     name: "Tiki wiki",
     load() {
-      return import("@codemirror/legacy-modes/mode/tiki").then(m => legacy(m.tiki))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-tiki" */("@codemirror/legacy-modes/mode/tiki").then(m => legacy(m.tiki))
     }
   }),
   LanguageDescription.of({
     name: "TOML",
     extensions: ["toml"],
     load() {
-      return import("@codemirror/legacy-modes/mode/toml").then(m => legacy(m.toml))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-toml" */("@codemirror/legacy-modes/mode/toml").then(m => legacy(m.toml))
     }
   }),
   LanguageDescription.of({
     name: "Troff",
     extensions: ["1","2","3","4","5","6","7","8","9"],
     load() {
-      return import("@codemirror/legacy-modes/mode/troff").then(m => legacy(m.troff))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-troff" */("@codemirror/legacy-modes/mode/troff").then(m => legacy(m.troff))
     }
   }),
   LanguageDescription.of({
     name: "TTCN",
     extensions: ["ttcn","ttcn3","ttcnpp"],
     load() {
-      return import("@codemirror/legacy-modes/mode/ttcn").then(m => legacy(m.ttcn))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-ttcn" */("@codemirror/legacy-modes/mode/ttcn").then(m => legacy(m.ttcn))
     }
   }),
   LanguageDescription.of({
     name: "TTCN_CFG",
     extensions: ["cfg"],
     load() {
-      return import("@codemirror/legacy-modes/mode/ttcn-cfg").then(m => legacy(m.ttcnCfg))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-ttcn-cfg" */("@codemirror/legacy-modes/mode/ttcn-cfg").then(m => legacy(m.ttcnCfg))
     }
   }),
   LanguageDescription.of({
     name: "Turtle",
     extensions: ["ttl"],
     load() {
-      return import("@codemirror/legacy-modes/mode/turtle").then(m => legacy(m.turtle))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-turtle" */("@codemirror/legacy-modes/mode/turtle").then(m => legacy(m.turtle))
     }
   }),
   LanguageDescription.of({
     name: "Web IDL",
     extensions: ["webidl"],
     load() {
-      return import("@codemirror/legacy-modes/mode/webidl").then(m => legacy(m.webIDL))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-webidl" */("@codemirror/legacy-modes/mode/webidl").then(m => legacy(m.webIDL))
     }
   }),
   LanguageDescription.of({
     name: "VB.NET",
     extensions: ["vb"],
     load() {
-      return import("@codemirror/legacy-modes/mode/vb").then(m => legacy(m.vb))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-vb" */("@codemirror/legacy-modes/mode/vb").then(m => legacy(m.vb))
     }
   }),
   LanguageDescription.of({
     name: "VBScript",
     extensions: ["vbs"],
     load() {
-      return import("@codemirror/legacy-modes/mode/vbscript").then(m => legacy(m.vbScript))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-vbscript" */("@codemirror/legacy-modes/mode/vbscript").then(m => legacy(m.vbScript))
     }
   }),
   LanguageDescription.of({
     name: "Velocity",
     extensions: ["vtl"],
     load() {
-      return import("@codemirror/legacy-modes/mode/velocity").then(m => legacy(m.velocity))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-velocity" */("@codemirror/legacy-modes/mode/velocity").then(m => legacy(m.velocity))
     }
   }),
   LanguageDescription.of({
     name: "Verilog",
     extensions: ["v"],
     load() {
-      return import("@codemirror/legacy-modes/mode/verilog").then(m => legacy(m.verilog))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-verilog" */("@codemirror/legacy-modes/mode/verilog").then(m => legacy(m.verilog))
     }
   }),
   LanguageDescription.of({
     name: "VHDL",
     extensions: ["vhd","vhdl"],
     load() {
-      return import("@codemirror/legacy-modes/mode/vhdl").then(m => legacy(m.vhdl))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-vhdl" */("@codemirror/legacy-modes/mode/vhdl").then(m => legacy(m.vhdl))
     }
   }),
   LanguageDescription.of({
     name: "XQuery",
     extensions: ["xy","xquery"],
     load() {
-      return import("@codemirror/legacy-modes/mode/xquery").then(m => legacy(m.xQuery))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-xquery" */("@codemirror/legacy-modes/mode/xquery").then(m => legacy(m.xQuery))
     }
   }),
   LanguageDescription.of({
     name: "Yacas",
     extensions: ["ys"],
     load() {
-      return import("@codemirror/legacy-modes/mode/yacas").then(m => legacy(m.yacas))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-yacas" */("@codemirror/legacy-modes/mode/yacas").then(m => legacy(m.yacas))
     }
   }),
   LanguageDescription.of({
@@ -954,48 +954,48 @@ export const languages = [
     alias: ["yml"],
     extensions: ["yaml","yml"],
     load() {
-      return import("@codemirror/legacy-modes/mode/yaml").then(m => legacy(m.yaml))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-yaml" */("@codemirror/legacy-modes/mode/yaml").then(m => legacy(m.yaml))
     }
   }),
   LanguageDescription.of({
     name: "Z80",
     extensions: ["z80"],
     load() {
-      return import("@codemirror/legacy-modes/mode/z80").then(m => legacy(m.z80))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-z80" */("@codemirror/legacy-modes/mode/z80").then(m => legacy(m.z80))
     }
   }),
   LanguageDescription.of({
     name: "MscGen",
     extensions: ["mscgen","mscin","msc"],
     load() {
-      return import("@codemirror/legacy-modes/mode/mscgen").then(m => legacy(m.mscgen))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-mscgen" */("@codemirror/legacy-modes/mode/mscgen").then(m => legacy(m.mscgen))
     }
   }),
   LanguageDescription.of({
     name: "Xù",
     extensions: ["xu"],
     load() {
-      return import("@codemirror/legacy-modes/mode/mscgen").then(m => legacy(m.xu))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-mscgen" */("@codemirror/legacy-modes/mode/mscgen").then(m => legacy(m.xu))
     }
   }),
   LanguageDescription.of({
     name: "MsGenny",
     extensions: ["msgenny"],
     load() {
-      return import("@codemirror/legacy-modes/mode/mscgen").then(m => legacy(m.msgenny))
+      return import/* webpackChunkName: "codemirror-lang-legacy-mode-mscgen" */("@codemirror/legacy-modes/mode/mscgen").then(m => legacy(m.msgenny))
     }
   }),
   LanguageDescription.of({
     name: "Vue",
     extensions: ["vue"],
     load() {
-      return import("@codemirror/lang-vue").then(m => m.vue())
+      return import/* webpackChunkName: "codemirror-lang-vue" */("@codemirror/lang-vue").then(m => m.vue())
     }
   }),
   LanguageDescription.of({
     name: "Angular Template",
     load() {
-      return import("@codemirror/lang-angular").then(m => m.angular())
+      return import/* webpackChunkName: "codemirror-lang-angular" */("@codemirror/lang-angular").then(m => m.angular())
     }
   })
 ]


### PR DESCRIPTION
There are hundreds of languages in codemirror, when a webapp using codemirror is packaged into a bundle, hundreds of js files with unclear names will be generated. Based on webpack's [magic comment](https://webpack.js.org/api/module-methods/#magic-comments) we can optimize this.