### PR TITLE
Add mts and cts to TypeScript language extensions

### DIFF
--- a/src/language-data.ts
+++ b/src/language-data.ts
@@ -174,7 +174,7 @@ export const languages = [
   LanguageDescription.of({
     name: "TypeScript",
     alias: ["ts"],
-    extensions: ["ts", "mts", "cts"],
+    extensions: ["ts","mts","cts"],
     load() {
       return import("@codemirror/lang-javascript").then(m => m.javascript({typescript: true}))
     }

--- a/src/language-data.ts
+++ b/src/language-data.ts
@@ -174,7 +174,7 @@ export const languages = [
   LanguageDescription.of({
     name: "TypeScript",
     alias: ["ts"],
-    extensions: ["ts"],
+    extensions: ["ts", "mts", "cts"],
     load() {
       return import("@codemirror/lang-javascript").then(m => m.javascript({typescript: true}))
     }


### PR DESCRIPTION
TypeScript utilizes `mts` and `cts` extensions for special modules. 
https://www.typescriptlang.org/docs/handbook/modules/reference.html#module-format-detection

The JavaScript equivalents (`mjs` and `cjs` repectively) are already in language-data for JS, so this change adds the TypeScript variants to TypeScript's language data.