### PR TITLE
Add additional extensions for XQuery language

### DIFF
--- a/src/language-data.ts
+++ b/src/language-data.ts
@@ -960,7 +960,7 @@ export const languages = [
   }),
   LanguageDescription.of({
     name: "XQuery",
-    extensions: ["xy","xquery"],
+    extensions: ["xy","xquery","xq","xqm","xqy"],
     load() {
       return import("@codemirror/legacy-modes/mode/xquery").then(m => legacy(m.xQuery))
     }


### PR DESCRIPTION
See https://stackoverflow.com/questions/51637619/xquery-filename-extensions

I have never seen `xy` used for `XQuery`, maybe it is a typo for `xqy` but keeping for compatibility.